### PR TITLE
User mode variant of multiservice plugin with shared spec examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ cap STAGE systemd:example1:setup systemd:example2:setup
 cap STAGE deploy
 ```
 
+### User services
+
+To have the service installed under your own user rather than root
+
+```ruby
+require "capistrano/systemd/multiservice"
+install_plugin Capistrano::Systemd::MultiService.new_service("example1", service_type: 'user')
+install_plugin Capistrano::Systemd::MultiService.new_service("example2", service_type: 'user')
+```
+
+If using the user service type services will be installed in your users home directory under ``` /.config/systemd/user ```.
+Systemd commands on those services can be run by passing a `--user` flag, e.g. ```systemctl --user list-unit-files```
+Nothing else in setup should require change and Capistrano tasks should remain the same as when installing system services.
+
 ## Capistrano Tasks
 
 With `install_plugin Capistrano::Systemd::MultiService.new_service("example1")`,

--- a/lib/capistrano/systemd/multiservice.rb
+++ b/lib/capistrano/systemd/multiservice.rb
@@ -1,11 +1,22 @@
 require "capistrano/systemd/multiservice/version"
 require "capistrano/systemd/multiservice/system_service"
+require "capistrano/systemd/multiservice/user_service"
 
 module Capistrano
   module Systemd
     module MultiService
-      def self.new_service(app)
-        SystemService.new(app)
+      SERVICE_TYPES = %w[system user].freeze
+
+      class ServiceTypeError < RuntimeError; end
+
+      def self.new_service(app, service_type: 'system')
+        service_type = service_type.to_s
+        unless SERVICE_TYPES.include?(service_type)
+          raise ServiceTypeError,
+                "Service type has to be one of #{SERVICE_TYPES}"
+        end
+
+        const_get("#{service_type.capitalize}Service").new(app)
       end
     end
   end

--- a/lib/capistrano/systemd/multiservice/system_service.rb
+++ b/lib/capistrano/systemd/multiservice/system_service.rb
@@ -71,6 +71,10 @@ module Capistrano
           }
         end
 
+        def default_units_dir
+          "/etc/systemd/system"
+        end
+
         def setup
           fetch(:"#{prefix}_units_src").zip(fetch(:"#{prefix}_units_dest")).each do |src, dest|
             buf = StringIO.new(ERB.new(File.read(src), nil, 2).result(binding))
@@ -104,10 +108,6 @@ module Capistrano
         def systemctl(*args)
           args.unshift :sudo, :systemctl
           backend.execute(*args)
-        end
-
-        def default_units_dir
-          "/etc/systemd/system"
         end
 
         private

--- a/lib/capistrano/systemd/multiservice/user_service.rb
+++ b/lib/capistrano/systemd/multiservice/user_service.rb
@@ -1,0 +1,28 @@
+require_relative './system_service'
+
+module Capistrano
+  module Systemd
+    module MultiService
+      class UserService < SystemService
+        def systemctl(*args)
+          args.unshift :systemctl, '--user'
+          backend.execute(*args)
+        end
+
+        def remove
+          backend.execute :rm, '-f', '--', fetch(:"#{prefix}_units_dest")
+        end
+
+        def default_units_dir
+          "/home/#{fetch(:user)}/.config/systemd/user"
+        end
+
+        protected
+
+        def setup_service(buf, src, dest)
+          backend.upload! buf, dest
+        end
+      end
+    end
+  end
+end

--- a/lib/capistrano/systemd/multiservice/version.rb
+++ b/lib/capistrano/systemd/multiservice/version.rb
@@ -1,7 +1,7 @@
 module Capistrano
   module Systemd
     module MultiService
-      VERSION = "0.1.0.beta6"
+      VERSION = "0.1.0.beta7"
     end
   end
 end

--- a/spec/capistrano/systemd/multiservice/user_service_spec.rb
+++ b/spec/capistrano/systemd/multiservice/user_service_spec.rb
@@ -1,10 +1,12 @@
 require "spec_helper"
 
-describe Capistrano::Systemd::MultiService::SystemService do
-  let(:systemd_dir) { "/etc/systemd/system" }
-  let(:systemctl_command) { %i[sudo systemctl] }
+describe Capistrano::Systemd::MultiService::UserService do
+  let(:systemd_dir) { "/home/user/.config/systemd/user" }
+  let(:systemctl_command) { [:systemctl, "--user"] }
 
   include_context "setup"
+
+  before { env.set :user, "user" }
 
   context do
     include_context "with config/systemd/example1.service.erb"
@@ -15,9 +17,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
         File.expects(:read).with("config/systemd/example1.service.erb").returns("dummy")
         StringIO.expects(:new).with("dummy").returns(buf)
 
-        backend.expects(:upload!).with(buf, "/tmp/example1.service")
-        backend.expects(:sudo).with(:install, "-m 644 -o root -g root -D", "/tmp/example1.service", "/etc/systemd/system/foo_example1.service")
-        backend.expects(:execute).with(:rm, "/tmp/example1.service")
+        backend.expects(:upload!).with(buf, "/home/user/.config/systemd/user/foo_example1.service")
 
         subject.setup
       end
@@ -25,7 +25,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
 
     describe "#remove" do
       it "should uninstall unit file" do
-        backend.expects(:sudo).with(:rm, '-f', '--', ["/etc/systemd/system/foo_example1.service"])
+        backend.expects(:execute).with(:rm, '-f', '--', ["/home/user/.config/systemd/user/foo_example1.service"])
 
         subject.remove
       end
@@ -41,17 +41,13 @@ describe Capistrano::Systemd::MultiService::SystemService do
         File.expects(:read).with("config/systemd/example2.service.erb").returns("dummy1")
         StringIO.expects(:new).with("dummy1").returns(buf1)
 
-        backend.expects(:upload!).with(buf1, "/tmp/example2.service")
-        backend.expects(:sudo).with(:install, "-m 644 -o root -g root -D", "/tmp/example2.service", "/etc/systemd/system/foo_example2.service")
-        backend.expects(:execute).with(:rm, "/tmp/example2.service")
+        backend.expects(:upload!).with(buf1, "/home/user/.config/systemd/user/foo_example2.service")
 
         buf2 = stub
         File.expects(:read).with("config/systemd/example2@.service.erb").returns("dummy2")
         StringIO.expects(:new).with("dummy2").returns(buf2)
 
-        backend.expects(:upload!).with(buf2, "/tmp/example2@.service")
-        backend.expects(:sudo).with(:install, "-m 644 -o root -g root -D", "/tmp/example2@.service", "/etc/systemd/system/foo_example2@.service")
-        backend.expects(:execute).with(:rm, "/tmp/example2@.service")
+        backend.expects(:upload!).with(buf2, "/home/user/.config/systemd/user/foo_example2@.service")
 
         subject.setup
       end
@@ -59,7 +55,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
 
     describe "#remove" do
       it "should uninstall unit file" do
-        backend.expects(:sudo).with(:rm, '-f', '--', ["/etc/systemd/system/foo_example2.service", "/etc/systemd/system/foo_example2@.service"])
+        backend.expects(:execute).with(:rm, '-f', '--', ["/home/user/.config/systemd/user/foo_example2.service", "/home/user/.config/systemd/user/foo_example2@.service"])
 
         subject.remove
       end
@@ -75,9 +71,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
         File.expects(:read).with("config/systemd/example3@.service.erb").returns("dummy2")
         StringIO.expects(:new).with("dummy2").returns(buf2)
 
-        backend.expects(:upload!).with(buf2, "/tmp/example3@.service")
-        backend.expects(:sudo).with(:install, "-m 644 -o root -g root -D", "/tmp/example3@.service", "/etc/systemd/system/foo_example3@.service")
-        backend.expects(:execute).with(:rm, "/tmp/example3@.service")
+        backend.expects(:upload!).with(buf2, "#{systemd_dir}/foo_example3@.service")
 
         subject.setup
       end
@@ -85,7 +79,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
 
     describe "#remove" do
       it "should uninstall unit file" do
-        backend.expects(:sudo).with(:rm, '-f', '--', ["/etc/systemd/system/foo_example3@.service"])
+        backend.expects(:execute).with(:rm, '-f', '--', ["#{systemd_dir}/foo_example3@.service"])
 
         subject.remove
       end
@@ -93,6 +87,6 @@ describe Capistrano::Systemd::MultiService::SystemService do
   end
 
   include_examples "without config file" do
-    let(:systemctl_command) { %i[sudo systemctl] }
+    let(:systemctl_command) { [:systemctl, "--user"] }
   end
 end

--- a/spec/capistrano/systemd/multiservice_spec.rb
+++ b/spec/capistrano/systemd/multiservice_spec.rb
@@ -2,16 +2,29 @@ require "spec_helper"
 
 describe Capistrano::Systemd::MultiService do
   it "has a version number" do
-    expect(Capistrano::Systemd::MultiService::VERSION).not_to be nil
+    expect(described_class::VERSION).not_to be nil
   end
 
-  describe "Capistrano::Systemd::MultiService.new_service" do
+  describe ".new_service" do
     context "with 'example' argument" do
-      subject {
-        Capistrano::Systemd::MultiService.new_service('example')
-      }
+      subject { described_class.new_service('example') }
+
       it do
-        expect(subject).to be_an_instance_of(Capistrano::Systemd::MultiService::SystemService).and have_attributes(app: "example")
+        expect(subject).to be_an_instance_of(described_class::SystemService).and have_attributes(app: "example")
+      end
+    end
+
+    context 'when asking for user service type' do
+      subject { described_class.new_service('example', service_type: 'user') }
+
+      it { is_expected.to be_a(described_class::UserService) }
+    end
+
+    context 'when asking for non-existent service type' do
+      subject { described_class.new_service('example', service_type: 'xyz') }
+
+      it 'exits with exception' do
+        expect { subject }.to raise_error(described_class::ServiceTypeError)
       end
     end
   end

--- a/spec/capistrano/systemd/shared/example1.rb
+++ b/spec/capistrano/systemd/shared/example1.rb
@@ -1,0 +1,72 @@
+RSpec.shared_context "with config/systemd/example1.service.erb" do
+  subject { described_class.new("example1") }
+
+  before do
+    env.install_plugin subject, load_immediately: true
+    Dir.expects(:[]).with("config/systemd/example1{,@}.*.erb").returns(["config/systemd/example1.service.erb"]).at_most_once
+  end
+
+  describe "variables" do
+    it "systemd_example1_units_src" do
+      expect(env.fetch(:systemd_example1_units_src)).to eq ["config/systemd/example1.service.erb"]
+    end
+
+    it "systemd_example1_units_dest" do
+      expect(env.fetch(:systemd_example1_units_dest)).to eq ["#{systemd_dir}/foo_example1.service"]
+    end
+
+    it "systemd_example1_instances" do
+      expect(env.fetch(:systemd_example1_instances)).to eq nil
+    end
+
+    it "systemd_example1_service" do
+      expect(env.fetch(:systemd_example1_service)).to eq "foo_example1.service"
+    end
+
+    it "systemd_example1_instance_services" do
+      expect(env.fetch(:systemd_example1_instance_services)).to eq []
+    end
+  end
+
+  describe "#validate" do
+    it "does not exit if unit file exist" do
+      backend.expects(:test).with("[ -f #{systemd_dir}/foo_example1.service ]").returns(true)
+
+      subject.validate
+    end
+
+    it "exit if unit file does not exist" do
+      backend.expects(:test).with("[ -f #{systemd_dir}/foo_example1.service ]").returns(false)
+      backend.expects(:error).with("#{systemd_dir}/foo_example1.service not found")
+
+      expect{ subject.validate }.to raise_error SystemExit
+    end
+  end
+
+  describe "#restart" do
+    it "should run systemctl restart foo_example1.service" do
+      command = systemctl_command + [:restart, "foo_example1.service"]
+      backend.expects(:execute).with(*command)
+
+      subject.restart
+    end
+  end
+
+  describe "#reload_or_restart" do
+    it "should run systemctl reload-or-restart foo_example1.service" do
+      command = systemctl_command + [:"reload-or-restart", "foo_example1.service"]
+      backend.expects(:execute).with(*command)
+
+      subject.reload_or_restart
+    end
+  end
+
+  describe "#enable" do
+    it "should run systemctl enable foo_example1.service" do
+      command = systemctl_command + [:enable, "foo_example1.service"]
+      backend.expects(:execute).with(*command)
+
+      subject.enable
+    end
+  end
+end

--- a/spec/capistrano/systemd/shared/example2.rb
+++ b/spec/capistrano/systemd/shared/example2.rb
@@ -1,0 +1,74 @@
+RSpec.shared_context "with config/systemd/example2.service.erb, example2@.service.erb" do
+  subject { described_class.new("example2") }
+
+  before do
+    env.install_plugin subject, load_immediately: true
+    Dir.expects(:[]).with("config/systemd/example2{,@}.*.erb").returns(["config/systemd/example2.service.erb", "config/systemd/example2@.service.erb"]).at_most_once
+  end
+
+  describe "variables" do
+    it "systemd_example2_units_src" do
+      expect(env.fetch(:systemd_example2_units_src)).to eq ["config/systemd/example2.service.erb", "config/systemd/example2@.service.erb"]
+    end
+
+    it "systemd_example2_units_dest" do
+      expect(env.fetch(:systemd_example2_units_dest)).to eq ["#{systemd_dir}/foo_example2.service", "#{systemd_dir}/foo_example2@.service"]
+    end
+
+    it "systemd_example2_instances" do
+      expect(env.fetch(:systemd_example2_instances)).to eq [0]
+    end
+
+    it "systemd_example2_service" do
+      expect(env.fetch(:systemd_example2_service)).to eq "foo_example2.service"
+    end
+
+    it "systemd_example2_instance_services" do
+      expect(env.fetch(:systemd_example2_instance_services)).to eq ["foo_example2@0.service"]
+    end
+  end
+
+  describe "#validate" do
+    it "does not exit if unit file exist" do
+      backend.expects(:test).with("[ -f #{systemd_dir}/foo_example2.service ]").returns(true)
+      backend.expects(:test).with("[ -f #{systemd_dir}/foo_example2@.service ]").returns(true)
+
+      subject.validate
+    end
+
+    it "exit if unit file does not exist" do
+      backend.expects(:test).with("[ -f #{systemd_dir}/foo_example2.service ]").returns(true)
+      backend.expects(:test).with("[ -f #{systemd_dir}/foo_example2@.service ]").returns(false)
+      backend.expects(:error).with("#{systemd_dir}/foo_example2@.service not found")
+
+      expect{ subject.validate }.to raise_error SystemExit
+    end
+  end
+
+  describe "#restart" do
+    it "should run systemctl restart foo_example2.service" do
+      command = systemctl_command + [:restart, "foo_example2.service"]
+      backend.expects(:execute).with(*command)
+
+      subject.restart
+    end
+  end
+
+  describe "#reload_or_restart" do
+    it "should run systemctl reload-or-restart foo_example2.service" do
+      command = systemctl_command + [:"reload-or-restart", "foo_example2.service"]
+      backend.expects(:execute).with(*command)
+
+      subject.reload_or_restart
+    end
+  end
+
+  describe "#enable" do
+    it "should run systemctl enable foo_example2.service" do
+      command = systemctl_command + [:enable, "foo_example2.service"]
+      backend.expects(:execute).with(*command)
+
+      subject.enable
+    end
+  end
+end

--- a/spec/capistrano/systemd/shared/example3.rb
+++ b/spec/capistrano/systemd/shared/example3.rb
@@ -1,0 +1,69 @@
+RSpec.shared_context 'with config/systemd/example3@.service.erb' do
+  subject { described_class.new("example3") }
+
+  before do
+    env.install_plugin subject, load_immediately: true
+    env.set :systemd_example3_instances, ["bar", "baz", "qux"]
+    Dir.expects(:[]).with("config/systemd/example3{,@}.*.erb").returns(["config/systemd/example3@.service.erb"]).at_most_once
+  end
+
+  describe "variables" do
+    it "systemd_example3_units_src" do
+      expect(env.fetch(:systemd_example3_units_src)).to eq ["config/systemd/example3@.service.erb"]
+    end
+
+    it "systemd_example3_units_dest" do
+      expect(env.fetch(:systemd_example3_units_dest)).to eq ["#{systemd_dir}/foo_example3@.service"]
+    end
+
+    it "systemd_example3_service" do
+      expect(env.fetch(:systemd_example3_service)).to eq ["foo_example3@bar.service", "foo_example3@baz.service", "foo_example3@qux.service"]
+    end
+
+    it "systemd_example3_instance_services" do
+      expect(env.fetch(:systemd_example3_instance_services)).to eq ["foo_example3@bar.service", "foo_example3@baz.service", "foo_example3@qux.service"]
+    end
+  end
+
+  describe "#validate" do
+    it "does not exit if unit file exist" do
+      backend.expects(:test).with("[ -f #{systemd_dir}/foo_example3@.service ]").returns(true)
+
+      subject.validate
+    end
+
+    it "exit if unit file does not exist" do
+      backend.expects(:test).with("[ -f #{systemd_dir}/foo_example3@.service ]").returns(false)
+      backend.expects(:error).with("#{systemd_dir}/foo_example3@.service not found")
+
+      expect{ subject.validate }.to raise_error SystemExit
+    end
+  end
+
+  describe "#restart" do
+    it "should run systemctl restart foo_example3.service" do
+      command = systemctl_command + [:restart, ["foo_example3@bar.service", "foo_example3@baz.service", "foo_example3@qux.service"]]
+      backend.expects(:execute).with(*command)
+
+      subject.restart
+    end
+  end
+
+  describe "#reload_or_restart" do
+    it "should run systemctl reload-or-restart foo_example3.service" do
+      command = systemctl_command + [:"reload-or-restart", ["foo_example3@bar.service", "foo_example3@baz.service", "foo_example3@qux.service"]]
+      backend.expects(:execute).with(*command)
+
+      subject.reload_or_restart
+    end
+  end
+
+  describe "#enable" do
+    it "should run systemctl enable foo_example3.service" do
+      command = systemctl_command + [:enable, ["foo_example3@bar.service", "foo_example3@baz.service", "foo_example3@qux.service"]]
+      backend.expects(:execute).with(*command)
+
+      subject.enable
+    end
+  end
+end

--- a/spec/capistrano/systemd/shared/setup.rb
+++ b/spec/capistrano/systemd/shared/setup.rb
@@ -1,0 +1,54 @@
+RSpec.shared_context "setup" do
+  subject { described_class.new("example") }
+
+  # This allows us to easily use `set`, `fetch`, etc. in the examples.
+  let(:env){ Capistrano::Configuration.env }
+
+  # Stub the SSHKit backend so we can set up expectations without the plugin
+  # actually executing any commands.
+  let(:backend) { stub }
+  before { SSHKit::Backend.stubs(:current).returns(backend) }
+
+  # Mimic the deploy flow tasks so that the plugin can register its hooks.
+  before do
+    Rake::Task.define_task("deploy:check")
+    env.set :application, "foo"
+    env.set :tmp_dir, "/tmp"
+  end
+
+  # Clean up any tasks or variables that the plugin defined.
+  after do
+    Rake::Task.clear
+    Capistrano::Configuration.reset!
+  end
+
+  describe "#nsp" do
+    it "should be :example" do
+      expect(subject.nsp).to eq :example
+    end
+  end
+
+  describe "#prefix" do
+    it "should be systemd_example" do
+      expect(subject.prefix).to eq "systemd_example"
+    end
+  end
+
+  describe "#systemctl" do
+    it "should run sudo systemctl with arg" do
+      command = systemctl_command + [:status]
+      backend.expects(:execute).with(*command)
+
+      subject.systemctl(:status)
+    end
+  end
+
+  describe "#daemon_reload" do
+    it "should run sudo systemctl daemon-reload" do
+      command = systemctl_command + [:"daemon-reload"]
+      backend.expects(:execute).with(*command)
+
+      subject.daemon_reload
+    end
+  end
+end

--- a/spec/capistrano/systemd/shared/without_config_file.rb
+++ b/spec/capistrano/systemd/shared/without_config_file.rb
@@ -1,0 +1,67 @@
+name = 'without config file'
+RSpec.shared_examples name do
+  context name do
+    subject { described_class.new("example4") }
+
+    before do
+      env.install_plugin subject, load_immediately: true
+      env.set :systemd_example4_service, "example4.service"
+      Dir.expects(:[]).with("config/systemd/example4{,@}.*.erb").returns([]).at_most_once
+    end
+
+    describe "variables" do
+      it "systemd_example4_units_src" do
+        expect(env.fetch :systemd_example4_units_src).to eq []
+      end
+
+      it "systemd_example4_units_dest" do
+        expect(env.fetch(:systemd_example4_units_dest)).to eq []
+      end
+
+      it "systemd_example4_instances" do
+        expect(env.fetch(:systemd_example4_instances)).to eq nil
+      end
+
+      it "systemd_example4_service" do
+        expect(env.fetch(:systemd_example4_service)).to eq "example4.service"
+      end
+
+      it "systemd_example4_instance_services" do
+        expect(env.fetch(:systemd_example4_instance_services)).to eq []
+      end
+    end
+
+    describe "#validate" do
+      it do
+        expect{ subject.validate }.not_to raise_error
+      end
+    end
+
+    describe "#restart" do
+      it "should run systemctl restart example4.service" do
+        command = systemctl_command + [:restart, "example4.service"]
+        backend.expects(:execute).with(*command)
+
+        subject.restart
+      end
+    end
+
+    describe "#reload_or_restart" do
+      it "should run systemctl reload-or-restart example4.service" do
+        command = systemctl_command + [:"reload-or-restart", "example4.service"]
+        backend.expects(:execute).with(*command)
+
+        subject.reload_or_restart
+      end
+    end
+
+    describe "#enable" do
+      it "should run systemctl enable example4.service" do
+        command = systemctl_command + [:enable, "example4.service"]
+        backend.expects(:execute).with(*command)
+
+        subject.enable
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,13 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "rspec"
 require "mocha/api"
 require "capistrano/systemd/multiservice"
+require "capistrano/systemd/multiservice/system_service"
+require "capistrano/systemd/multiservice/user_service"
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.mock_framework = :mocha
   config.order = "random"
 end
+
+Dir["#{__dir__}/capistrano/systemd/shared/*.rb"].each { |file| require file }


### PR DESCRIPTION
Hi! I needed services to be deployed in the user directory so that they could be managed like so for example: `systemctl --user list-unit-files`. 
To that end I created a subclass of `MultiService` called `UserMultiService`. The difference is in default directory location and in the way commands are executed - user services don't need sudo permission. I kept changes to the base class as minimal as possible so existing functionality should remain unaffected.
The biggest change is actually to the specs - cause I needed to test all the same cases without having duplication, I extracted all the examples into the shared directory and used them for both classes.

Let me know please if you see any problems with this and would you have interest in merging the changes upstream.