### PR TITLE
support access to `server` in .service template

### DIFF
--- a/lib/capistrano/systemd/multiservice/system_service.rb
+++ b/lib/capistrano/systemd/multiservice/system_service.rb
@@ -75,18 +75,18 @@ module Capistrano
           "/etc/systemd/system"
         end
 
-        def setup
+        def setup(server)
           fetch(:"#{prefix}_units_src").zip(fetch(:"#{prefix}_units_dest")).each do |src, dest|
             buf = StringIO.new(ERB.new(File.read(src), nil, 2).result(binding))
             setup_service buf, src, dest
           end
         end
 
-        def remove
+        def remove(_server)
           backend.sudo :rm, '-f', '--', fetch(:"#{prefix}_units_dest")
         end
 
-        def validate
+        def validate(_server)
           fetch(:"#{prefix}_units_dest").each do |dest|
             unless backend.test("[ -f #{dest} ]")
               backend.error "#{dest} not found"
@@ -95,12 +95,12 @@ module Capistrano
           end
         end
 
-        def daemon_reload
+        def daemon_reload(_server)
           systemctl :"daemon-reload"
         end
 
         %i[start stop reload restart reload-or-restart enable disable].each do |act|
-          define_method act.to_s.tr('-','_') do
+          define_method act.to_s.tr('-','_') do |_server|
             systemctl act, fetch(:"#{prefix}_service")
           end
         end

--- a/lib/capistrano/systemd/multiservice/user_service.rb
+++ b/lib/capistrano/systemd/multiservice/user_service.rb
@@ -9,7 +9,7 @@ module Capistrano
           backend.execute(*args)
         end
 
-        def remove
+        def remove(_server)
           backend.execute :rm, '-f', '--', fetch(:"#{prefix}_units_dest")
         end
 

--- a/lib/capistrano/tasks/systemd/multiservice/system_service.rake
+++ b/lib/capistrano/tasks/systemd/multiservice/system_service.rake
@@ -18,8 +18,8 @@ namespace :systemd do
     }.each do |task_name, desc_template|
       desc(desc_template % { app: svc.app, task_name: task_name})
       task task_name do
-        on roles(fetch(:"#{svc.prefix}_role")) do
-          svc.__send__ task_name.to_s.tr('-', '_')
+        on roles(fetch(:"#{svc.prefix}_role")) do |server|
+          svc.__send__ task_name.to_s.tr('-', '_'), server
         end
       end
     end

--- a/spec/capistrano/systemd/multiservice/system_service_spec.rb
+++ b/spec/capistrano/systemd/multiservice/system_service_spec.rb
@@ -19,7 +19,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
         backend.expects(:sudo).with(:install, "-m 644 -o root -g root -D", "/tmp/example1.service", "/etc/systemd/system/foo_example1.service")
         backend.expects(:execute).with(:rm, "/tmp/example1.service")
 
-        subject.setup
+        subject.setup(server)
       end
     end
 
@@ -27,7 +27,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
       it "should uninstall unit file" do
         backend.expects(:sudo).with(:rm, '-f', '--', ["/etc/systemd/system/foo_example1.service"])
 
-        subject.remove
+        subject.remove(server)
       end
     end
   end
@@ -53,7 +53,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
         backend.expects(:sudo).with(:install, "-m 644 -o root -g root -D", "/tmp/example2@.service", "/etc/systemd/system/foo_example2@.service")
         backend.expects(:execute).with(:rm, "/tmp/example2@.service")
 
-        subject.setup
+        subject.setup(server)
       end
     end
 
@@ -61,7 +61,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
       it "should uninstall unit file" do
         backend.expects(:sudo).with(:rm, '-f', '--', ["/etc/systemd/system/foo_example2.service", "/etc/systemd/system/foo_example2@.service"])
 
-        subject.remove
+        subject.remove(server)
       end
     end
   end
@@ -79,7 +79,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
         backend.expects(:sudo).with(:install, "-m 644 -o root -g root -D", "/tmp/example3@.service", "/etc/systemd/system/foo_example3@.service")
         backend.expects(:execute).with(:rm, "/tmp/example3@.service")
 
-        subject.setup
+        subject.setup(server)
       end
     end
 
@@ -87,7 +87,7 @@ describe Capistrano::Systemd::MultiService::SystemService do
       it "should uninstall unit file" do
         backend.expects(:sudo).with(:rm, '-f', '--', ["/etc/systemd/system/foo_example3@.service"])
 
-        subject.remove
+        subject.remove(server)
       end
     end
   end

--- a/spec/capistrano/systemd/multiservice/user_service_spec.rb
+++ b/spec/capistrano/systemd/multiservice/user_service_spec.rb
@@ -19,7 +19,7 @@ describe Capistrano::Systemd::MultiService::UserService do
 
         backend.expects(:upload!).with(buf, "/home/user/.config/systemd/user/foo_example1.service")
 
-        subject.setup
+        subject.setup(server)
       end
     end
 
@@ -27,7 +27,7 @@ describe Capistrano::Systemd::MultiService::UserService do
       it "should uninstall unit file" do
         backend.expects(:execute).with(:rm, '-f', '--', ["/home/user/.config/systemd/user/foo_example1.service"])
 
-        subject.remove
+        subject.remove(server)
       end
     end
   end
@@ -49,7 +49,7 @@ describe Capistrano::Systemd::MultiService::UserService do
 
         backend.expects(:upload!).with(buf2, "/home/user/.config/systemd/user/foo_example2@.service")
 
-        subject.setup
+        subject.setup(server)
       end
     end
 
@@ -57,7 +57,7 @@ describe Capistrano::Systemd::MultiService::UserService do
       it "should uninstall unit file" do
         backend.expects(:execute).with(:rm, '-f', '--', ["/home/user/.config/systemd/user/foo_example2.service", "/home/user/.config/systemd/user/foo_example2@.service"])
 
-        subject.remove
+        subject.remove(server)
       end
     end
   end
@@ -73,7 +73,7 @@ describe Capistrano::Systemd::MultiService::UserService do
 
         backend.expects(:upload!).with(buf2, "#{systemd_dir}/foo_example3@.service")
 
-        subject.setup
+        subject.setup(server)
       end
     end
 
@@ -81,7 +81,7 @@ describe Capistrano::Systemd::MultiService::UserService do
       it "should uninstall unit file" do
         backend.expects(:execute).with(:rm, '-f', '--', ["#{systemd_dir}/foo_example3@.service"])
 
-        subject.remove
+        subject.remove(server)
       end
     end
   end

--- a/spec/capistrano/systemd/shared/example1.rb
+++ b/spec/capistrano/systemd/shared/example1.rb
@@ -1,6 +1,8 @@
 RSpec.shared_context "with config/systemd/example1.service.erb" do
   subject { described_class.new("example1") }
 
+  let(:server) { env.server "1.2.3.4", roles: %w{all}, server_property: 42 }
+
   before do
     env.install_plugin subject, load_immediately: true
     Dir.expects(:[]).with("config/systemd/example1{,@}.*.erb").returns(["config/systemd/example1.service.erb"]).at_most_once
@@ -32,14 +34,14 @@ RSpec.shared_context "with config/systemd/example1.service.erb" do
     it "does not exit if unit file exist" do
       backend.expects(:test).with("[ -f #{systemd_dir}/foo_example1.service ]").returns(true)
 
-      subject.validate
+      subject.validate(server)
     end
 
     it "exit if unit file does not exist" do
       backend.expects(:test).with("[ -f #{systemd_dir}/foo_example1.service ]").returns(false)
       backend.expects(:error).with("#{systemd_dir}/foo_example1.service not found")
 
-      expect{ subject.validate }.to raise_error SystemExit
+      expect{ subject.validate(server) }.to raise_error SystemExit
     end
   end
 
@@ -48,7 +50,7 @@ RSpec.shared_context "with config/systemd/example1.service.erb" do
       command = systemctl_command + [:restart, "foo_example1.service"]
       backend.expects(:execute).with(*command)
 
-      subject.restart
+      subject.restart(server)
     end
   end
 
@@ -57,7 +59,7 @@ RSpec.shared_context "with config/systemd/example1.service.erb" do
       command = systemctl_command + [:"reload-or-restart", "foo_example1.service"]
       backend.expects(:execute).with(*command)
 
-      subject.reload_or_restart
+      subject.reload_or_restart(server)
     end
   end
 
@@ -66,7 +68,7 @@ RSpec.shared_context "with config/systemd/example1.service.erb" do
       command = systemctl_command + [:enable, "foo_example1.service"]
       backend.expects(:execute).with(*command)
 
-      subject.enable
+      subject.enable(server)
     end
   end
 end

--- a/spec/capistrano/systemd/shared/example2.rb
+++ b/spec/capistrano/systemd/shared/example2.rb
@@ -1,6 +1,8 @@
 RSpec.shared_context "with config/systemd/example2.service.erb, example2@.service.erb" do
   subject { described_class.new("example2") }
 
+  let(:server) { env.server "1.2.3.4", roles: %w{all}, server_property: 42 }
+
   before do
     env.install_plugin subject, load_immediately: true
     Dir.expects(:[]).with("config/systemd/example2{,@}.*.erb").returns(["config/systemd/example2.service.erb", "config/systemd/example2@.service.erb"]).at_most_once
@@ -33,7 +35,7 @@ RSpec.shared_context "with config/systemd/example2.service.erb, example2@.servic
       backend.expects(:test).with("[ -f #{systemd_dir}/foo_example2.service ]").returns(true)
       backend.expects(:test).with("[ -f #{systemd_dir}/foo_example2@.service ]").returns(true)
 
-      subject.validate
+      subject.validate(server)
     end
 
     it "exit if unit file does not exist" do
@@ -41,7 +43,7 @@ RSpec.shared_context "with config/systemd/example2.service.erb, example2@.servic
       backend.expects(:test).with("[ -f #{systemd_dir}/foo_example2@.service ]").returns(false)
       backend.expects(:error).with("#{systemd_dir}/foo_example2@.service not found")
 
-      expect{ subject.validate }.to raise_error SystemExit
+      expect{ subject.validate(server) }.to raise_error SystemExit
     end
   end
 
@@ -50,7 +52,7 @@ RSpec.shared_context "with config/systemd/example2.service.erb, example2@.servic
       command = systemctl_command + [:restart, "foo_example2.service"]
       backend.expects(:execute).with(*command)
 
-      subject.restart
+      subject.restart(server)
     end
   end
 
@@ -59,7 +61,7 @@ RSpec.shared_context "with config/systemd/example2.service.erb, example2@.servic
       command = systemctl_command + [:"reload-or-restart", "foo_example2.service"]
       backend.expects(:execute).with(*command)
 
-      subject.reload_or_restart
+      subject.reload_or_restart(server)
     end
   end
 
@@ -68,7 +70,7 @@ RSpec.shared_context "with config/systemd/example2.service.erb, example2@.servic
       command = systemctl_command + [:enable, "foo_example2.service"]
       backend.expects(:execute).with(*command)
 
-      subject.enable
+      subject.enable(server)
     end
   end
 end

--- a/spec/capistrano/systemd/shared/example3.rb
+++ b/spec/capistrano/systemd/shared/example3.rb
@@ -1,6 +1,8 @@
 RSpec.shared_context 'with config/systemd/example3@.service.erb' do
   subject { described_class.new("example3") }
 
+  let(:server) { env.server "1.2.3.4", roles: %w{all}, server_property: 42 }
+
   before do
     env.install_plugin subject, load_immediately: true
     env.set :systemd_example3_instances, ["bar", "baz", "qux"]
@@ -29,14 +31,14 @@ RSpec.shared_context 'with config/systemd/example3@.service.erb' do
     it "does not exit if unit file exist" do
       backend.expects(:test).with("[ -f #{systemd_dir}/foo_example3@.service ]").returns(true)
 
-      subject.validate
+      subject.validate(server)
     end
 
     it "exit if unit file does not exist" do
       backend.expects(:test).with("[ -f #{systemd_dir}/foo_example3@.service ]").returns(false)
       backend.expects(:error).with("#{systemd_dir}/foo_example3@.service not found")
 
-      expect{ subject.validate }.to raise_error SystemExit
+      expect{ subject.validate(server) }.to raise_error SystemExit
     end
   end
 
@@ -45,7 +47,7 @@ RSpec.shared_context 'with config/systemd/example3@.service.erb' do
       command = systemctl_command + [:restart, ["foo_example3@bar.service", "foo_example3@baz.service", "foo_example3@qux.service"]]
       backend.expects(:execute).with(*command)
 
-      subject.restart
+      subject.restart(server)
     end
   end
 
@@ -54,7 +56,7 @@ RSpec.shared_context 'with config/systemd/example3@.service.erb' do
       command = systemctl_command + [:"reload-or-restart", ["foo_example3@bar.service", "foo_example3@baz.service", "foo_example3@qux.service"]]
       backend.expects(:execute).with(*command)
 
-      subject.reload_or_restart
+      subject.reload_or_restart(server)
     end
   end
 
@@ -63,7 +65,7 @@ RSpec.shared_context 'with config/systemd/example3@.service.erb' do
       command = systemctl_command + [:enable, ["foo_example3@bar.service", "foo_example3@baz.service", "foo_example3@qux.service"]]
       backend.expects(:execute).with(*command)
 
-      subject.enable
+      subject.enable(server)
     end
   end
 end

--- a/spec/capistrano/systemd/shared/setup.rb
+++ b/spec/capistrano/systemd/shared/setup.rb
@@ -3,6 +3,7 @@ RSpec.shared_context "setup" do
 
   # This allows us to easily use `set`, `fetch`, etc. in the examples.
   let(:env){ Capistrano::Configuration.env }
+  let(:server) { env.server "1.2.3.4", roles: %w{all}, server_property: 42 }
 
   # Stub the SSHKit backend so we can set up expectations without the plugin
   # actually executing any commands.
@@ -48,7 +49,7 @@ RSpec.shared_context "setup" do
       command = systemctl_command + [:"daemon-reload"]
       backend.expects(:execute).with(*command)
 
-      subject.daemon_reload
+      subject.daemon_reload(server)
     end
   end
 end

--- a/spec/capistrano/systemd/shared/without_config_file.rb
+++ b/spec/capistrano/systemd/shared/without_config_file.rb
@@ -3,6 +3,8 @@ RSpec.shared_examples name do
   context name do
     subject { described_class.new("example4") }
 
+    let(:server) { env.server "1.2.3.4", roles: %w{all}, server_property: 42 }
+
     before do
       env.install_plugin subject, load_immediately: true
       env.set :systemd_example4_service, "example4.service"
@@ -33,7 +35,7 @@ RSpec.shared_examples name do
 
     describe "#validate" do
       it do
-        expect{ subject.validate }.not_to raise_error
+        expect{ subject.validate(server) }.not_to raise_error
       end
     end
 
@@ -42,7 +44,7 @@ RSpec.shared_examples name do
         command = systemctl_command + [:restart, "example4.service"]
         backend.expects(:execute).with(*command)
 
-        subject.restart
+        subject.restart(server)
       end
     end
 
@@ -51,7 +53,7 @@ RSpec.shared_examples name do
         command = systemctl_command + [:"reload-or-restart", "example4.service"]
         backend.expects(:execute).with(*command)
 
-        subject.reload_or_restart
+        subject.reload_or_restart(server)
       end
     end
 
@@ -60,7 +62,7 @@ RSpec.shared_examples name do
         command = systemctl_command + [:enable, "example4.service"]
         backend.expects(:execute).with(*command)
 
-        subject.enable
+        subject.enable(server)
       end
     end
   end


### PR DESCRIPTION
this change can do like this:

config/deploy/xxxx.rb
```rb
server "1.2.3.4", roles: %w{app web db}, puma_port: 8080
```

config/systemd/puma.service.erb
```rb
...

[Service]
...
ExecStart=bundle exec puma -C <%= current_path %>/config/puma.rb -p <%= server.properties.puma_port %>

...
```

I update a lot of rspecs, but I'm not sure it is right... :(
