### PR TITLE
Removed bundler gem version specifier from gemspec file

### DIFF
--- a/capistrano-systemd-multiservice.gemspec
+++ b/capistrano-systemd-multiservice.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", ">= 3.7.0", "< 3.12.0"
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "mocha", "~> 1.2"


### PR DESCRIPTION
in #15, CI failed.

https://travis-ci.org/groovenauts/capistrano-systemd-multiservice/jobs/660439514?utm_medium=notification&utm_source=github_status

```console
$ rvm use 2.5.3 --install --binary --fuzzy
$ export BUNDLE_GEMFILE=$PWD/Gemfile
$ ruby --version
$ gem install bundler -v 1.17.2
$ bundle install --jobs=3 --retry=3
Fetching gem metadata from https://rubygems.org/..........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.13)

  Current Bundler version:
    bundler (2.0.1)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.13)' in any of the relevant sources:
  the local ruby installation
```

So removed bundler gem version specifier from gemspec file.